### PR TITLE
Support standard deviation in the statistical metrics gathered

### DIFF
--- a/app/models/probe.rb
+++ b/app/models/probe.rb
@@ -83,7 +83,7 @@ module Hopper
       end
     end
 
-    # Collect all the averages!
+    # Collect all the statistical base metric!
     #
     # Returns an Array of OpenStructs (defined with :name and :average).
     def self.metrics
@@ -95,6 +95,7 @@ module Hopper
           :mean    => values.average,
           :median  => values.median,
           :mode    => values.mode.first
+          :stdiv   => values.standard_deviation
       end
     end
 

--- a/app/models/probe.rb
+++ b/app/models/probe.rb
@@ -83,7 +83,7 @@ module Hopper
       end
     end
 
-    # Collect all the statistical base metric!
+    # Collect all the statistical base metrics!
     #
     # Returns an Array of OpenStructs (defined with :name and :average).
     def self.metrics


### PR DESCRIPTION
Because it's a good metric, heck it's a nessesary metric. 

In case you've forgotten some of stats 101: 
- [Variance](http://en.wikipedia.org/wiki/Variance) shows how spread out the numbers are, hence the name. It is basically computed as the average distance from the mean. 
- [Standard deviation](http://en.wikipedia.org/wiki/Standard_deviation#Basic_examples) is basically each distance from the mean, like with the variance, only squared (so as to avoid having negative numbers) then averaged and square rooted.

I changed the [app/models/probe.rb](https://github.com/KarlHerler/hopper/blob/patch-1/app/models/probe.rb) to support add support for standard deviations, not sure if it's the right spot but seemed the best (although the documentation only mentioned averages so I changed that). 
I havent tested it to be honest, the method exists in [rstats](http://rubydoc.info/gems/rstats/0.0.4/Array:squares_of_deviations) so it should be peachy-fine but nevertheless **you've been warned**.
